### PR TITLE
grpcio 1.42.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,8 +20,8 @@ if [[ "$target_platform" == osx-* ]]; then
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then
-    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument"
-    export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument"
+    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
+    export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
 fi
 
 ln -s "$(which $CC)" "$SRC_DIR/cc"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+# grpci requires a specific minimum SDK
+# https://github.com/grpc/grpc/blob/v1.39.0/setup.py#L415
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - "10.10"                # [osx and x86_64]
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "10.10"                # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ source:
   patches:
     - 0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
     - 0002-windows-ssl-lib-names.patch
-    #- 0001-fix-win-setup.patch
     - 0001-fix-win-commands.patch
-    #- fix_sysroot.patch
 
 build:
   number: 0
-  skip: true  # [python_impl == 'pypy']
+  skip: True  # [python_impl == 'pypy']
+  skip: True  # [py<36]
+  missing_dso_whitelist:
+    - $RPATH/ld64.so.1  # [s390x]
 
 requirements:
   build:
@@ -26,24 +27,24 @@ requirements:
     - patch  # [not win]
   host:
     - python
-    - pip
-    - setuptools
-    - cython
-    - six >=1.5.2
-    - zlib
-    - coverage
-    - openssl
     - c-ares            # [unix]
+    - coverage >=4.0
+    - cython >=0.29.8
+    - openssl
+    - pip
     - pthread-stubs     # [linux]
-  run:
-    - python
-    - cython
+    - re2               # [unix]
     - setuptools
+    - six >=1.10
+    - wheel >=0.29
+    - zlib
+  run:
+    - python >=3.6
+    - openssl
     - six >=1.5.2
     - zlib
-    - coverage
-    - openssl
     - {{ pin_compatible("c-ares") }}  # [unix]
+    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.36.1" %}
+{% set version = "1.42.0" %}
 
 package:
   name: grpcio
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/grpcio/grpcio-{{ version }}.tar.gz
-  sha256: a66ea59b20f3669df0f0c6a3bd57b985e5b2d1dcf3e4c29819bb8dc232d0fd38
+  sha256: 4a8f2c7490fe3696e0cdd566e2f099fb91b51bc75446125175c55581c2f7bc11
   patches:
     - 0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
     - 0002-windows-ssl-lib-names.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - openssl
     - pip
     - pthread-stubs     # [linux]
-    - re2               # [unix]
     - setuptools
     - six >=1.10
     - wheel >=0.29

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,16 +15,15 @@ source:
     - fix_sysroot.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [python_impl == 'pypy']
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    # - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - m2-patch  # [win]
+    - patch  # [not win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   patches:
     - 0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
     - 0002-windows-ssl-lib-names.patch
-    - 0001-fix-win-setup.patch
+    #- 0001-fix-win-setup.patch
     - 0001-fix-win-commands.patch
     - fix_sysroot.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-windows-ssl-lib-names.patch
     #- 0001-fix-win-setup.patch
     - 0001-fix-win-commands.patch
-    - fix_sysroot.patch
+    #- fix_sysroot.patch
 
 build:
   number: 0


### PR DESCRIPTION
Update grpcio to 1.42.0

Version change: bump version number from 1.36.1 to 1.42.0
Bug Tracker: new open issues https://github.com/grpc/grpc/issues
Github releases:  https://github.com/grpc/grpc/releases
Upstream License: https://github.com/grpc/grpc/blob/master/LICENSE
Upstream setup file: https://github.com/grpc/grpc/blob/v1.42.0/setup.py and https://github.com/grpc/grpc/blob/v1.42.0/requirements.txt


The package grpcio is mentioned inside the packages:
google-api-core | googleapis-common-protos | grpcio-gcp | grpcio-tools | grpcio-tools-1.16.1 | ray-packages | tensorflow-base | tensorflow-gpu-base |

Actions:
1. Skip py<36
2. Update host and run dependencies
3. Add conda_build_config.yaml with a minimun MacOS SDK
4. Add missing_dso_whitelist:
    `- $RPATH/ld64.so.1  # [s390x]`

Result:
- all-succeeded