### PR TITLE
Rebuild for python 3.10 support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,8 @@ if [[ "$target_platform" == osx-* ]]; then
 fi
 
 if [[  "$(uname -m)" = "ppc64le" ]]; then
-    export LIBS="$LIBS -lpthread"
+    export CFLAGS="$CFLAGS -lpthread"
+    export CXXFLAGS="$CXXFLAGS -lpthread"
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,16 +6,23 @@ export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL="True"
 export GRPC_PYTHON_BUILD_SYSTEM_CARES="True"
 export GRPC_PYTHON_USE_PREBUILT_GRPC_CORE=""
 export GRPC_PYTHON_BUILD_WITH_CYTHON="True"
+export GRPC_BUILD_PREFIX=${PREFIX}
 
 if [[ "${target_platform}" == linux-* ]]; then
     # set these so the default in setup.py are not used
     # it seems that we need to link to pthrad on linux or osx.
     export GRPC_PYTHON_LDFLAGS="-lpthread"
 elif [[ "$target_platform" == osx-* ]]; then
+    export CC=$(basename "${CC}")
     export GRPC_PYTHON_LDFLAGS=" -framework CoreFoundation"
+    # cp $RECIPE_DIR/clang_wrapper.sh $SRC_DIR/$CC
+    # chmod +x $SRC_DIR/$CC
+    export SYSTEM_VERSION_COMPAT=1
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then
+    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
+    export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
     export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,32 +1,22 @@
 #!/bin/bash
 
-# set these so the default in setup.py are not used
-export GRPC_PYTHON_LDFLAGS=""
-
 export GRPC_BUILD_WITH_BORING_SSL_ASM=""
 export GRPC_PYTHON_BUILD_SYSTEM_ZLIB="True"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL="True"
 export GRPC_PYTHON_BUILD_SYSTEM_CARES="True"
 export GRPC_PYTHON_USE_PREBUILT_GRPC_CORE=""
 export GRPC_PYTHON_BUILD_WITH_CYTHON="True"
-export GRPC_BUILD_PREFIX=${PREFIX}
 
-if [[ "$target_platform" == osx-* ]]; then
-    export CC=$(basename "${CC}")
+if [[ "${target_platform}" == linux-* ]]; then
+    # set these so the default in setup.py are not used
+    # it seems that we need to link to pthrad on linux or osx.
+    export GRPC_PYTHON_LDFLAGS="-lpthread"
+elif [[ "$target_platform" == osx-* ]]; then
     export GRPC_PYTHON_LDFLAGS=" -framework CoreFoundation"
-    # cp $RECIPE_DIR/clang_wrapper.sh $SRC_DIR/$CC
-    # chmod +x $SRC_DIR/$CC
-    export SYSTEM_VERSION_COMPAT=1
-fi
-
-if [[  "$(uname -m)" = "ppc64le" ]]; then
-    export CFLAGS="$CFLAGS -lpthread"
-    export CXXFLAGS="$CXXFLAGS -lpthread"
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then
-    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
-    export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
+    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"
 fi
 
 ln -s "$(which $CC)" "$SRC_DIR/cc"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,7 +23,6 @@ fi
 if [[ "$target_platform" == osx-64 ]]; then
     export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
     export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
-    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"
 fi
 
 ln -s "$(which $CC)" "$SRC_DIR/cc"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,8 +19,8 @@ if [[ "$target_platform" == osx-* ]]; then
     export SYSTEM_VERSION_COMPAT=1
 fi
 
-if [[ "$target_platform" == ppc64le ]]; then
-    export LIBS="-lpthread"
+if [[  "$(uname -m)" = "ppc64le" ]]; then
+    export LIBS="$LIBS -lpthread"
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,10 @@ if [[ "$target_platform" == osx-* ]]; then
     export SYSTEM_VERSION_COMPAT=1
 fi
 
+if [[ "$target_platform" == ppc64le ]]; then
+    export LIBS="-lpthread"
+fi
+
 if [[ "$target_platform" == osx-64 ]]; then
     export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
     export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  # trigger 1
   skip: True  # [python_impl == 'pypy']
   skip: True  # [py<36]
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,6 @@ test:
     - pip
   imports:
     - grpc
-    - grpc._cython
-    - grpc._cython._cygrpc
     - grpc.beta
     - grpc.framework
     - grpc.framework.common


### PR DESCRIPTION
Github releases:  https://github.com/grpc/grpc/releases
Upstream License: https://github.com/grpc/grpc/blob/master/LICENSE
Upstream setup file: https://github.com/grpc/grpc/blob/v1.42.0/setup.py and https://github.com/grpc/grpc/blob/v1.42.0/requirements.txt

Actions:
1. Update `build.sh` (from conda-forge https://github.com/conda-forge/grpcio-feedstock/blob/d6850ddd530626ec917cfec5682b355c7ca12593/recipe/build.sh)
2. Remove private modules from `imports`