### PR TITLE
grpcio 1.46.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,8 @@ if [[ "$target_platform" == osx-* ]]; then
 fi
 
 if [[  "$(uname -m)" = "ppc64le" ]]; then
-    export LIBS="$LIBS -lpthread"
+    export CFLAGS="$CFLAGS -lpthread"
+    export CXXFLAGS="$CXXFLAGS -lpthread"
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,27 +1,22 @@
 #!/bin/bash
 
-# set these so the default in setup.py are not used
-export GRPC_PYTHON_LDFLAGS=""
-
 export GRPC_BUILD_WITH_BORING_SSL_ASM=""
 export GRPC_PYTHON_BUILD_SYSTEM_ZLIB="True"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL="True"
 export GRPC_PYTHON_BUILD_SYSTEM_CARES="True"
 export GRPC_PYTHON_USE_PREBUILT_GRPC_CORE=""
 export GRPC_PYTHON_BUILD_WITH_CYTHON="True"
-export GRPC_BUILD_PREFIX=${PREFIX}
 
-if [[ "$target_platform" == osx-* ]]; then
-    export CC=$(basename "${CC}")
+if [[ "${target_platform}" == linux-* ]]; then
+    # set these so the default in setup.py are not used
+    # it seems that we need to link to pthrad on linux or osx.
+    export GRPC_PYTHON_LDFLAGS="-lpthread"
+elif [[ "$target_platform" == osx-* ]]; then
     export GRPC_PYTHON_LDFLAGS=" -framework CoreFoundation"
-    # cp $RECIPE_DIR/clang_wrapper.sh $SRC_DIR/$CC
-    # chmod +x $SRC_DIR/$CC
-    export SYSTEM_VERSION_COMPAT=1
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then
-    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
-    export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
+    export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1"
 fi
 
 ln -s "$(which $CC)" "$SRC_DIR/cc"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,11 +19,6 @@ if [[ "$target_platform" == osx-* ]]; then
     export SYSTEM_VERSION_COMPAT=1
 fi
 
-if [[  "$(uname -m)" = "ppc64le" ]]; then
-    export CFLAGS="$CFLAGS -lpthread"
-    export CXXFLAGS="$CXXFLAGS -lpthread"
-fi
-
 if [[ "$target_platform" == osx-64 ]]; then
     export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
     export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,8 +19,8 @@ if [[ "$target_platform" == osx-* ]]; then
     export SYSTEM_VERSION_COMPAT=1
 fi
 
-if [[ "$target_platform" == ppc64le ]]; then
-    export LIBS="-lpthread"
+if [[  "$(uname -m)" = "ppc64le" ]]; then
+    export LIBS="$LIBS -lpthread"
 fi
 
 if [[ "$target_platform" == osx-64 ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,10 @@ if [[ "$target_platform" == osx-* ]]; then
     export SYSTEM_VERSION_COMPAT=1
 fi
 
+if [[ "$target_platform" == ppc64le ]]; then
+    export LIBS="-lpthread"
+fi
+
 if [[ "$target_platform" == osx-64 ]]; then
     export CFLAGS="$CFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"
     export CXXFLAGS="$CXXFLAGS -DTARGET_OS_OSX=1 --sysroot /opt/MacOSX10.10.sdk/ -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-nullability-completeness"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   patches:
     - 0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
     - 0002-windows-ssl-lib-names.patch
-    - 0001-fix-win-setup.patch
     - 0001-fix-win-commands.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  # trigger 1
   skip: True  # [python_impl == 'pypy']
   skip: True  # [py<36]
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.42.0" %}
+{% set version = "1.46.3" %}
 
 package:
   name: grpcio
@@ -6,15 +6,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/grpcio/grpcio-{{ version }}.tar.gz
-  sha256: 4a8f2c7490fe3696e0cdd566e2f099fb91b51bc75446125175c55581c2f7bc11
+  sha256: 4b8fd8b1cd553635274b83cd984f0755e6779886eca53c1c71d48215962eb689
   patches:
     - 0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
     - 0002-windows-ssl-lib-names.patch
+    - 0001-fix-win-setup.patch
     - 0001-fix-win-commands.patch
 
 build:
   number: 0
-  # trigger 1
   skip: True  # [python_impl == 'pypy']
   skip: True  # [py<36]
   missing_dso_whitelist:
@@ -51,8 +51,6 @@ test:
     - pip
   imports:
     - grpc
-    - grpc._cython
-    - grpc._cython._cygrpc
     - grpc.beta
     - grpc.framework
     - grpc.framework.common
@@ -69,7 +67,8 @@ about:
   license_file: LICENSE
   license_family: APACHE
   summary: HTTP/2-based RPC framework
-  dev_url: https://pypi.org/project/grpcio/
+  dev_url: https://github.com/grpc/grpc
+  doc_url: https://grpc.io/docs/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update grpcio to 1.46.3

Version change: bump version number from 1.42.0 to 1.46.3
Bug Tracker: new open issues https://github.com/grpc/grpc/issues
Github releases:  https://github.com/grpc/grpc/releases
Upstream License: https://github.com/grpc/grpc/blob/master/LICENSE
Upstream setup file: https://github.com/grpc/grpc/blob/v1.46.3/setup.py and https://github.com/grpc/grpc/blob/v1.46.3/requirements.txt


The package grpcio is mentioned inside the packages:
google-api-core | googleapis-common-protos | grpcio-gcp | grpcio-tools | grpcio-tools-1.16.1 | ray-packages | tensorflow-base | tensorflow-gpu-base |

Actions:
1. Remove private imports
2. Update dev url
3. Add doc url